### PR TITLE
Add Django backend scaffold, configuration, core utilities, and infra files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+__pycache__/
+*.pyc
+*.sqlite3

--- a/backend/apps/__init__.py
+++ b/backend/apps/__init__.py
@@ -1,0 +1,1 @@
+"""Project apps package."""

--- a/backend/apps/accounts/__init__.py
+++ b/backend/apps/accounts/__init__.py
@@ -1,0 +1,1 @@
+"""Accounts app package."""

--- a/backend/apps/accounts/admin.py
+++ b/backend/apps/accounts/admin.py
@@ -1,0 +1,47 @@
+from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+
+from .models import User
+
+
+@admin.register(User)
+class UserAdmin(BaseUserAdmin):
+    model = User
+    ordering = ("-created_at",)
+    list_display = (
+        "email",
+        "first_name",
+        "last_name",
+        "is_staff",
+        "is_active",
+        "email_verified",
+        "created_at",
+    )
+    list_filter = ("is_staff", "is_active", "email_verified", "created_at")
+    search_fields = ("email", "first_name", "last_name", "phone", "stripe_customer_id")
+
+    fieldsets = (
+        (None, {"fields": ("email", "password")}),
+        ("Personal info", {"fields": ("first_name", "last_name", "phone", "stripe_customer_id")}),
+        ("Permissions", {"fields": ("is_active", "is_staff", "is_superuser", "email_verified", "groups", "user_permissions")}),
+        ("Important dates", {"fields": ("last_login", "created_at", "updated_at")}),
+    )
+    readonly_fields = ("created_at", "updated_at", "last_login")
+    add_fieldsets = (
+        (
+            None,
+            {
+                "classes": ("wide",),
+                "fields": (
+                    "email",
+                    "first_name",
+                    "last_name",
+                    "password1",
+                    "password2",
+                    "is_staff",
+                    "is_active",
+                    "email_verified",
+                ),
+            },
+        ),
+    )

--- a/backend/apps/accounts/apps.py
+++ b/backend/apps/accounts/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class AccountsConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.accounts"
+    label = "accounts"

--- a/backend/apps/accounts/managers.py
+++ b/backend/apps/accounts/managers.py
@@ -4,7 +4,7 @@ from django.contrib.auth.base_user import BaseUserManager
 class UserManager(BaseUserManager):
     use_in_migrations = True
 
-    def create_user(self, email: str, password: str | None = None, **extra_fields):
+    def create_user(self, email: str, password: str, **extra_fields):
         if not email:
             raise ValueError("The email field must be set")
 

--- a/backend/apps/accounts/managers.py
+++ b/backend/apps/accounts/managers.py
@@ -1,0 +1,27 @@
+from django.contrib.auth.base_user import BaseUserManager
+
+
+class UserManager(BaseUserManager):
+    use_in_migrations = True
+
+    def create_user(self, email: str, password: str | None = None, **extra_fields):
+        if not email:
+            raise ValueError("The email field must be set")
+
+        email = self.normalize_email(email)
+        user = self.model(email=email, **extra_fields)
+        user.set_password(password)
+        user.save(using=self._db)
+        return user
+
+    def create_superuser(self, email: str, password: str, **extra_fields):
+        extra_fields.setdefault("is_staff", True)
+        extra_fields.setdefault("is_superuser", True)
+        extra_fields.setdefault("is_active", True)
+
+        if extra_fields.get("is_staff") is not True:
+            raise ValueError("Superuser must have is_staff=True.")
+        if extra_fields.get("is_superuser") is not True:
+            raise ValueError("Superuser must have is_superuser=True.")
+
+        return self.create_user(email, password, **extra_fields)

--- a/backend/apps/accounts/migrations/0001_initial.py
+++ b/backend/apps/accounts/migrations/0001_initial.py
@@ -1,0 +1,54 @@
+import uuid
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = [("auth", "0012_alter_user_first_name_max_length")]
+
+    operations = [
+        migrations.CreateModel(
+            name="User",
+            fields=[
+                ("password", models.CharField(max_length=128, verbose_name="password")),
+                ("last_login", models.DateTimeField(blank=True, null=True, verbose_name="last login")),
+                ("is_superuser", models.BooleanField(default=False, help_text="Designates that this user has all permissions without explicitly assigning them.", verbose_name="superuser status")),
+                ("id", models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
+                ("email", models.EmailField(db_index=True, max_length=254, unique=True)),
+                ("first_name", models.CharField(max_length=150)),
+                ("last_name", models.CharField(max_length=150)),
+                ("phone", models.CharField(blank=True, max_length=32)),
+                ("stripe_customer_id", models.CharField(blank=True, max_length=255)),
+                ("is_active", models.BooleanField(default=True)),
+                ("is_staff", models.BooleanField(default=False)),
+                ("email_verified", models.BooleanField(default=False)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "groups",
+                    models.ManyToManyField(
+                        blank=True,
+                        help_text="The groups this user belongs to. A user will get all permissions granted to each of their groups.",
+                        related_name="user_set",
+                        related_query_name="user",
+                        to="auth.group",
+                        verbose_name="groups",
+                    ),
+                ),
+                (
+                    "user_permissions",
+                    models.ManyToManyField(
+                        blank=True,
+                        help_text="Specific permissions for this user.",
+                        related_name="user_set",
+                        related_query_name="user",
+                        to="auth.permission",
+                        verbose_name="user permissions",
+                    ),
+                ),
+            ],
+            options={"ordering": ["-created_at"]},
+        ),
+    ]

--- a/backend/apps/accounts/migrations/__init__.py
+++ b/backend/apps/accounts/migrations/__init__.py
@@ -1,0 +1,1 @@
+"""Accounts migrations package."""

--- a/backend/apps/accounts/models.py
+++ b/backend/apps/accounts/models.py
@@ -1,0 +1,35 @@
+import uuid
+
+from django.contrib.auth.models import AbstractBaseUser, PermissionsMixin
+from django.db import models
+
+from .managers import UserManager
+
+
+class User(AbstractBaseUser, PermissionsMixin):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    email = models.EmailField(unique=True, db_index=True)
+    first_name = models.CharField(max_length=150)
+    last_name = models.CharField(max_length=150)
+    phone = models.CharField(max_length=32, blank=True)
+    stripe_customer_id = models.CharField(max_length=255, blank=True)
+    is_active = models.BooleanField(default=True)
+    is_staff = models.BooleanField(default=False)
+    email_verified = models.BooleanField(default=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    objects = UserManager()
+
+    USERNAME_FIELD = "email"
+    REQUIRED_FIELDS = ["first_name", "last_name"]
+
+    class Meta:
+        ordering = ["-created_at"]
+
+    @property
+    def full_name(self) -> str:
+        return f"{self.first_name} {self.last_name}".strip()
+
+    def __str__(self) -> str:
+        return self.email

--- a/backend/apps/accounts/tests.py
+++ b/backend/apps/accounts/tests.py
@@ -1,0 +1,40 @@
+from django.test import TestCase
+
+from .models import User
+
+
+class UserManagerTests(TestCase):
+    def test_create_user(self):
+        user = User.objects.create_user(
+            email="user@example.com",
+            password="strong-pass-123",
+            first_name="Jane",
+            last_name="Doe",
+        )
+
+        self.assertEqual(user.email, "user@example.com")
+        self.assertTrue(user.check_password("strong-pass-123"))
+        self.assertFalse(user.is_staff)
+        self.assertFalse(user.is_superuser)
+
+    def test_email_normalization(self):
+        user = User.objects.create_user(
+            email="User@EXAMPLE.COM",
+            password="strong-pass-123",
+            first_name="John",
+            last_name="Doe",
+        )
+
+        self.assertEqual(user.email, "User@example.com")
+
+    def test_create_superuser(self):
+        user = User.objects.create_superuser(
+            email="admin@example.com",
+            password="strong-pass-123",
+            first_name="Admin",
+            last_name="User",
+        )
+
+        self.assertTrue(user.is_staff)
+        self.assertTrue(user.is_superuser)
+        self.assertTrue(user.is_active)

--- a/backend/config/asgi.py
+++ b/backend/config/asgi.py
@@ -1,0 +1,7 @@
+import os
+
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+application = get_asgi_application()

--- a/backend/config/settings/__init__.py
+++ b/backend/config/settings/__init__.py
@@ -1,0 +1,10 @@
+from decouple import config
+
+DJANGO_ENV = config("DJANGO_ENV", default="development")
+
+if DJANGO_ENV == "production":
+    from .production import *
+elif DJANGO_ENV == "test":
+    from .test import *
+else:
+    from .development import *

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+
+from decouple import Csv, config
+
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
+
+SECRET_KEY = config("DJANGO_SECRET_KEY", default="django-insecure-change-me")
+DEBUG = config("DJANGO_DEBUG", default=False, cast=bool)
+
+ALLOWED_HOSTS = config(
+    "DJANGO_ALLOWED_HOSTS",
+    default="127.0.0.1,localhost",
+    cast=Csv(),
+)
+
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "corsheaders",
+    "rest_framework",
+    "core",
+]
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+]
+
+ROOT_URLCONF = "config.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    }
+]
+
+WSGI_APPLICATION = "config.wsgi.application"
+ASGI_APPLICATION = "config.asgi.application"
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
+    }
+}
+
+AUTH_PASSWORD_VALIDATORS = [
+    {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
+    {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},
+    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
+    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
+]
+
+LANGUAGE_CODE = "en-us"
+TIME_ZONE = "UTC"
+USE_I18N = True
+USE_TZ = True
+
+STATIC_URL = "static/"
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+CORS_ALLOW_ALL_ORIGINS = config("DJANGO_CORS_ALLOW_ALL_ORIGINS", default=False, cast=bool)

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -23,6 +23,7 @@ INSTALLED_APPS = [
     "corsheaders",
     "rest_framework",
     "core",
+    "apps.accounts",
 ]
 
 MIDDLEWARE = [
@@ -79,3 +80,6 @@ STATIC_URL = "static/"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 CORS_ALLOW_ALL_ORIGINS = config("DJANGO_CORS_ALLOW_ALL_ORIGINS", default=False, cast=bool)
+
+
+AUTH_USER_MODEL = "accounts.User"

--- a/backend/config/settings/development.py
+++ b/backend/config/settings/development.py
@@ -1,0 +1,3 @@
+from .base import *
+
+DEBUG = True

--- a/backend/config/settings/production.py
+++ b/backend/config/settings/production.py
@@ -1,0 +1,9 @@
+from decouple import config
+
+from .base import *
+
+DEBUG = False
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+SECURE_SSL_REDIRECT = config("DJANGO_SECURE_SSL_REDIRECT", default=True, cast=bool)
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True

--- a/backend/config/settings/test.py
+++ b/backend/config/settings/test.py
@@ -1,0 +1,4 @@
+from .base import *
+
+DEBUG = False
+PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -1,0 +1,6 @@
+from django.contrib import admin
+from django.urls import path
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+]

--- a/backend/config/wsgi.py
+++ b/backend/config/wsgi.py
@@ -1,0 +1,7 @@
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+application = get_wsgi_application()

--- a/backend/core/exceptions.py
+++ b/backend/core/exceptions.py
@@ -1,0 +1,2 @@
+class CoreError(Exception):
+    """Base exception for backend core errors."""

--- a/backend/core/pagination.py
+++ b/backend/core/pagination.py
@@ -1,0 +1,7 @@
+from rest_framework.pagination import PageNumberPagination
+
+
+class DefaultPagination(PageNumberPagination):
+    page_size = 20
+    page_size_query_param = "page_size"
+    max_page_size = 100

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+import os
+import sys
+
+
+def main() -> None:
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,37 @@
+services:
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_DB: sateri
+      POSTGRES_USER: sateri
+      POSTGRES_PASSWORD: sateri
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U sateri -d sateri"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+
+  mailpit:
+    image: axllent/mailpit:latest
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+
+volumes:
+  postgres_data:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -2,19 +2,15 @@ services:
   postgres:
     image: postgres:17-alpine
     environment:
-      POSTGRES_DB: sateri
-      POSTGRES_USER: sateri
-      POSTGRES_PASSWORD: sateri
+      POSTGRES_DB: hunting_house
+      POSTGRES_USER: hunting
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-localdev}
     ports:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U sateri -d sateri"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
+      test: ["CMD-SHELL", "pg_isready -U hunting -d hunting_house"]
 
   redis:
     image: redis:7-alpine
@@ -22,13 +18,9 @@ services:
       - "6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 5s
 
   mailpit:
-    image: axllent/mailpit:latest
+    image: axllent/mailpit
     ports:
       - "1025:1025"
       - "8025:8025"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,61 @@
+[project]
+name = "sateri"
+version = "0.1.0"
+description = "Backend scaffold for the Sateri project"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+  "Django==6.0.*",
+  "djangorestframework",
+  "djangorestframework-simplejwt",
+  "django-cors-headers",
+  "python-decouple==3.8",
+  "psycopg[binary]",
+  "celery",
+  "redis",
+  "stripe",
+  "resend",
+  "structlog",
+  "gunicorn",
+  "httpx",
+]
+
+[dependency-groups]
+dev = [
+  "ruff",
+  "mypy",
+  "pytest",
+  "pytest-django",
+  "pytest-cov",
+  "factory-boy",
+  "django-debug-toolbar",
+  "django-stubs",
+  "djangorestframework-stubs",
+  "pre-commit",
+]
+
+[tool.uv]
+package = false
+
+[tool.ruff]
+target-version = "py313"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "N", "UP", "B", "S", "A", "C4", "DTZ", "DJ", "T20", "SIM", "RUF"]
+
+[tool.mypy]
+python_version = "3.13"
+strict = true
+plugins = ["mypy_django_plugin.main"]
+
+[[tool.mypy.overrides]]
+module = ["*.migrations.*"]
+ignore_errors = true
+
+[tool.django-stubs]
+django_settings_module = "config.settings.test"
+
+[tool.pytest.ini_options]
+DJANGO_SETTINGS_MODULE = "config.settings.test"
+python_files = ["tests.py", "test_*.py", "*_tests.py"]


### PR DESCRIPTION
### Motivation
- Provide a starting backend scaffold for the project with a configurable Django settings layout and basic infra to run services locally.
- Prepare developer tooling and packaging configuration so linters, type-checkers, and tests can be wired up consistently.

### Description
- Add project configuration package `backend/config` with `asgi.py`, `wsgi.py`, `urls.py`, and environment-driven settings loading in `settings/__init__.py` that imports `base`, `development`, `production`, or `test` modules.
- Implement `settings/base.py` with common Django settings and small environment-specific overrides in `settings/development.py`, `settings/production.py`, and `settings/test.py` (test uses `MD5PasswordHasher` and disables `DEBUG`).
- Add `manage.py`, a minimal `core` app with `exceptions.py` and `pagination.py`, and a top-level `.gitignore` that ignores virtualenvs, caches, and SQLite files.
- Add `pyproject.toml` with project dependencies, dev dependency group, and configuration for `ruff`, `mypy`, `django-stubs`, and `pytest` settings, and add `infra/docker-compose.yml` to bring up `postgres`, `redis`, and `mailpit` for local development.

### Testing
- No automated tests were executed as part of this change; `pytest` is configured in `pyproject.toml` for future test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b47df060fc8329b2d8638dcf6775e9)